### PR TITLE
Rollback axios to 0.18.1 due to error response retry bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bankid",
     "authentication"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "lib/bankid.js",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "url": "https://github.com/anyfin/bankid/issues"
   },
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.18.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,10 +90,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"


### PR DESCRIPTION
It seems axios 0.19.0 can get stuck in an infinite loop of retrying when receiving an error response from the server. Until that is fixed we need to rollback to 0.18.1 which still has https://nvd.nist.gov/vuln/detail/CVE-2019-10742 fixed