### PR TITLE
Fix: Fixed malformed collect params in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ client
     const timer = setInterval(() => {
       const done = () => clearInterval(timer);
       client
-        .collect(res.orderRef)
+        .collect({ orderRef: res.orderRef })
         .then(res => {
           if (res.status === "complete") {
             console.log(res.completionData);


### PR DESCRIPTION
The collect call param `res.orderRef` should be `{ orderRef: res.orderRef }`. Fixed it in this PR