### PR TITLE
Add missing interface definitions for AuthRequestV6

### DIFF
--- a/src/bankid.ts
+++ b/src/bankid.ts
@@ -410,6 +410,9 @@ interface AuthOptionalRequirementsV6 {
 export interface AuthRequestV6 {
   endUserIp: string;
   requirement?: AuthOptionalRequirementsV6;
+  userVisibleData?: string;
+  userVisibleDataFormat?: "simpleMarkdownV1";
+  userNonVisibleData?: string;
 }
 
 interface AuthResponseV6 extends AuthResponse {

--- a/src/bankid.ts
+++ b/src/bankid.ts
@@ -413,6 +413,10 @@ export interface AuthRequestV6 {
   userVisibleData?: string;
   userVisibleDataFormat?: "simpleMarkdownV1";
   userNonVisibleData?: string;
+  returnUrl?: string;
+  returnRisk?: boolean;
+  web?: boolean;
+  app?: boolean;
 }
 
 interface AuthResponseV6 extends AuthResponse {


### PR DESCRIPTION
Per the api specs for [/auth](https://www.bankid.com/utvecklare/guider/teknisk-integrationsguide/graenssnittsbeskrivning/auth) these fields are also supported:

```
userVisibleData?: string;
userVisibleDataFormat?: "simpleMarkdownV1";
userNonVisibleData?: string;
```

This PR adds those type definitions to `AuthRequestV6`.