### PR TITLE
chore: Bump node version to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "5.x"
   },
   "peerDependencies": {
-    "@types/node": ">=14 <21"
+    "@types/node": ">=14 <22"
   },
   "peerDependenciesMeta": {
     "@types/node": {


### PR DESCRIPTION
No more legacy peer deps!