### PR TITLE
chore: bump @types/node peer dep to support up to node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "5.x"
   },
   "peerDependencies": {
-    "@types/node": ">=14 <22"
+    "@types/node": ">=14 <25"
   },
   "peerDependenciesMeta": {
     "@types/node": {


### PR DESCRIPTION
Support `@types/node` up to version 24. Related comment: https://github.com/anyfin/bankid/pull/96#issuecomment-3126233723