### PR TITLE
fix(types): make v6 requirement fields optional

### DIFF
--- a/src/bankid.ts
+++ b/src/bankid.ts
@@ -400,11 +400,11 @@ export class BankIdClient {
 }
 
 interface AuthOptionalRequirementsV6 {
-  pinCode: boolean;
+  pinCode?: boolean;
   cardReader?: "class1" | "class2";
-  mrtd: boolean;
+  mrtd?: boolean;
   certificatePolicies?: string[];
-  personalNumber: string;
+  personalNumber?: string;
 }
 
 export interface AuthRequestV6 {


### PR DESCRIPTION
## Summary

The fields `pinCode`, `mrtd` and `personalNumber` in `AuthOptionalRequirementsV6` are typed as required, which prevents callers from passing a partial `requirement` object — even though the BankID v6 API treats all of them as optional.

```diff
 interface AuthOptionalRequirementsV6 {
-  pinCode: boolean;
+  pinCode?: boolean;
   cardReader?: "class1" | "class2";
-  mrtd: boolean;
+  mrtd?: boolean;
   certificatePolicies?: string[];
-  personalNumber: string;
+  personalNumber?: string;
 }
```

## Why

According to the official BankID v6 API specification ([/auth reference](https://developers.bankid.com/api-references/auth--sign/auth)), no field inside the `requirement` object is marked `Required`. Specifically:

- `pinCode` — *"Users are required to confirm the order with their security code even if they have biometrics activated."* No default-required behavior; the field is opt-in.
- `mrtd` — *"No identity confirmation is required by default."*
- `personalNumber` — describes filtering behavior when present, with no requirement to send it.
- `cardReader` — *"No card reader is required by default."*

The spec's own example for `/auth` sends `requirement` with only `personalNumber`:

```json
{
  "endUserIp": "192.168.1.2",
  "returnUrl": "...",
  "requirement": {
    "personalNumber": "200001012384"
  }
}
```

This usage is currently a TypeScript error with the existing types because `pinCode` and `mrtd` are required.

The interface name (`AuthOptional`Requirements`V6`) also indicates the original authoring intent was for these fields to be optional.

For reference, the .NET community's equivalent library [ActiveLogin.Authentication](https://github.com/ActiveLogin/ActiveLogin.Authentication/blob/main/src/ActiveLogin.Authentication.BankId.Api/Models/Requirement.cs) types all of these as nullable (`bool? pinCode = null, bool? mrtd = null, string? personalNumber = null`) with `JsonIgnore(WhenWritingDefault)` so they are omitted from the request payload when unset.

## Compatibility

Adding `?` to interface fields is backward-compatible — any existing code that passes all fields continues to type-check unchanged. `tsc` build passes locally.

## Test plan

- [x] `yarn build` passes
- [x] Verified that `client.authenticate({ endUserIp: "...", requirement: { personalNumber: "..." } })` now type-checks (matches spec example)